### PR TITLE
Fix visual bug

### DIFF
--- a/hide sidebar numbers/rendertype_text.vsh
+++ b/hide sidebar numbers/rendertype_text.vsh
@@ -29,7 +29,7 @@ void main() {
     
 	// delete sidebar numbers
 	if(	Position.z == 0.0 && // check if the depth is correct (0 for gui texts)
-			gl_Position.x >= 0.95 && gl_Position.y >= -0.35 && // check if the position matches the sidebar
+			gl_Position.x >= 0.94 && gl_Position.y >= -0.35 && // check if the position matches the sidebar
 			vertexColor.g == 84.0/255.0 && vertexColor.g == 84.0/255.0 && vertexColor.r == 252.0/255.0 && // check if the color is the sidebar red color
 			gl_VertexID <= 3 // check if it's the first character of a string
 		) gl_Position = ProjMat * ModelViewMat * vec4(ScreenSize + 100.0, 0.0, 0.0); // move the vertices offscreen, idk if this is a good solution for that but vec4(0.0) doesnt do the trick for everyone


### PR DESCRIPTION
<img width="425" alt="image" src="https://user-images.githubusercontent.com/41289688/196721490-1289ae34-1676-4230-8d5b-0ffb6018e0b7.png">
This fixes above bug. This happened on specific resolutions and was confirmed by other people too.
As you can see, after this change the bug is fixed:
<img width="416" alt="image" src="https://user-images.githubusercontent.com/41289688/196721706-cef295cc-2d6c-4b6c-a56a-be21cfb95936.png">

Also it would be nice to hear your feedback on making `gl_VertexID` to be less than or equal `4` instead `3` as this will remove 2nd character (which is very common in scoreboards).